### PR TITLE
LPS-74910 calculate selectedGroupIds after request

### DIFF
--- a/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -374,8 +374,34 @@ public class AssetBrowserDisplayContext {
 		PortletURL portletURL = _renderResponse.createRenderURL();
 
 		portletURL.setParameter("groupId", String.valueOf(getGroupId()));
-		portletURL.setParameter(
-			"selectedGroupIds", StringUtil.merge(getSelectedGroupIds()));
+
+		long[] selectedGroupIds = StringUtil.split(
+			ParamUtil.getString(_request, "selectedGroupIds"), 0L);
+
+		if (selectedGroupIds.length == 0) {
+			long sharedContentCompanyId = ParamUtil.getLong(
+				_request, "sharedContentCompanyId");
+			long shareContentSiteGroupId = ParamUtil.getLong(
+				_request, "shareContentSiteGroupId");
+			long sharedContentUserId = ParamUtil.getLong(
+				_request, "sharedContentUserId");
+
+			portletURL.setParameter(
+				"sharedContentCompanyId",
+				String.valueOf(sharedContentCompanyId));
+
+			portletURL.setParameter(
+				"shareContentSiteGroupId",
+				String.valueOf(shareContentSiteGroupId));
+
+			portletURL.setParameter(
+				"sharedContentUserId", String.valueOf(sharedContentUserId));
+		}
+		else {
+			portletURL.setParameter(
+				"selectedGroupIds", StringUtil.merge(getSelectedGroupIds()));
+		}
+
 		portletURL.setParameter(
 			"refererAssetEntryId", String.valueOf(getRefererAssetEntryId()));
 		portletURL.setParameter("typeSelection", getTypeSelection());
@@ -409,6 +435,24 @@ public class AssetBrowserDisplayContext {
 	public long[] getSelectedGroupIds() {
 		long[] selectedGroupIds = StringUtil.split(
 			ParamUtil.getString(_request, "selectedGroupIds"), 0L);
+
+		if (selectedGroupIds.length == 0) {
+			long sharedContentCompanyId = ParamUtil.getLong(
+				_request, "sharedContentCompanyId");
+			long sharedContentSiteGroupId = ParamUtil.getLong(
+				_request, "sharedContentSiteGroupId");
+			long sharedContentUserId = ParamUtil.getLong(
+				_request, "sharedContentUserId");
+
+			try {
+				selectedGroupIds = PortalUtil.getSharedContentSiteGroupIds(
+					sharedContentCompanyId, sharedContentSiteGroupId,
+					sharedContentUserId);
+			}
+			catch (PortalException pe) {
+				pe.printStackTrace();
+			}
+		}
 
 		return selectedGroupIds;
 	}


### PR DESCRIPTION
/cc @SpencerWoo

This PR requires a fix in the com-liferay-journal here: https://github.com/liferay/com-liferay-journal/pull/484

Notes from Spencer:
> https://issues.liferay.com/browse/LPS-74910
> 
> Instead of passing selectedGroupIds in the request (giving a 414 error) we pass companyId, groupId, userId to be used to calculate selectedGroupIds outside the request.